### PR TITLE
mix sentence pair

### DIFF
--- a/datasets/datasets.py
+++ b/datasets/datasets.py
@@ -12,13 +12,22 @@ import random
 
 
 class KorSTSDatasets(Dataset):
-    def __init__(self, dir, model_name):
+    def __init__(self, dir, model_name, bi_directional_training):
         tsv = pd.read_csv(dir)
         tokenizer = AutoTokenizer.from_pretrained(model_name)
+        print("Data encoding...")
         self.s1 = [tokenizer.encode(s1) for s1 in tsv["sentence_1"]]
         self.s2 = [tokenizer.encode(s2) for s2 in tsv["sentence_2"]]
         self.y = tsv["label"]
         self.pad_id = tokenizer.pad_token_id
+        print("Done!")
+
+        if bi_directional_training:
+            print("data augmenting...")
+            self.s1 += self.s2
+            self.s2 += self.s1
+            self.y += self.y
+            print("Done!")
 
     def __len__(self):
         return len(self.y)

--- a/train.py
+++ b/train.py
@@ -30,8 +30,10 @@ def main(config):
 
     if not config["test_mode"]:
         run = wandb.init(project="sentence_bert", entity="nlp-13", config=config, name=config['log_name'], notes=config['notes'])
-
-    train_datasets = KorSTSDatasets(config['train_csv'], config['base_model'])
+    
+    print("Training set")
+    train_datasets = KorSTSDatasets(config['train_csv'], config['base_model'], True)
+    print("Validation set")
     valid_datasets = KorSTSDatasets(config['valid_csv'], config['base_model'])
 
     # get pad_token_id.


### PR DESCRIPTION
**문장 쌍을 뒤집는 코드 추가** 및 모델 전처리 과정을 확인하기 위해 중간 중간 print문 추가.

## Description
문장 쌍의 순서를 바꾸는 data augmentation을 적용해 봤습니다.
https://www.notion.so/_STS-ee28ac428c4a49189db27c6509379e58#081dcf5458424940bbc0ec174f91b073
위 링크와 같이 실험을 통해 loss가 줄어드는 것을 확인했기 때문에 push 합니다.

아, jupyter notebook도 commit 안되게 .gitignore에 추가했습니다.

## Changes I made
KorSTSDatasets 클래스에 bi_directional_training이라는 boolean 인자를 추가해서 True로 줄 경우, 정방향으로 학습한 뒤, 역방향으로도 학습을 합니다. 즉, 1에포크의 step수가 2배로 늘어나게 되니 참고해주세요.

## To reviewers
.

## Checklist
[✔] Base branch와 compare branch를 올바르게 선택했습니다.
[✔] PR 내용에 알맞은 label을 선택했습니다.
[✔] 팀이 공유하는 requirements와 일치하는 환경에서 작업했습니다.
[✔] 팀이 공유하는 convention에 따라 파일/문서를 추가/수정했습니다.