### PR TITLE
SimCSE unsupervised training process 추가 및 기타 config 추가.

### DIFF
--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -1,2 +1,2 @@
-from .datasets import KorSTSDatasets, Collate_fn, bucket_pair_indices, KorSTSDatasets_for_BERT, KorNLIDatasets, KorSTSDatasets_for_MLM
+from .datasets import *
 

--- a/datasets/datasets.py
+++ b/datasets/datasets.py
@@ -135,6 +135,14 @@ class KorSTSDatasets_for_MLM(KorSTSDatasets):
         label = torch.IntTensor(label)
 
         return sentence, label
+    
+class KorSTSDatasets_for_SimCSE(KorSTSDatasets):
+    def __init__(self, dir, model_name, stopword=False):
+        super(KorSTSDatasets_for_SimCSE, self).__init__(dir, model_name, stopword)
+        self.sentences = self.s1 + self.s2
+        
+    def __getitem__(self, idx):
+        return torch.IntTensor(self.sentences[idx])
 
 class Collate_fn(object):
     def __init__(self, pad_id=0, model_type="SBERT"):
@@ -185,6 +193,11 @@ class Collate_fn(object):
                 labels.append(y)
             inputs = pad_sequence(inputs, batch_first=True, padding_value=self.pad_id)
             labels = pad_sequence(labels, batch_first=True, padding_value=self.pad_id)
+            return inputs.long(), labels.long()
+        elif self.model_type == "SimCSE":
+            inputs = [b for b in batch]
+            labels = torch.arange(len(inputs))
+            inputs = pad_sequence(inputs, batch_first=True, padding_value=self.pad_id)
             return inputs.long(), labels.long()
 
 def bucket_pair_indices(

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,1 +1,1 @@
-from .auto_models import SBERT_base_Model, BERT_base_Model, BERT_base_NLI_Model, MLM_Model
+from .auto_models import *

--- a/models/auto_models.py
+++ b/models/auto_models.py
@@ -3,9 +3,9 @@ import torch.nn as nn
 import torch
 
 class SBERT_base_Model(nn.Module):
-    def __init__(self, model_name):
+    def __init__(self, model_name, dropout_prob):
         super(SBERT_base_Model, self).__init__()
-        self.bert = AutoModel.from_pretrained(model_name)
+        self.bert = AutoModel.from_pretrained(model_name, hidden_dropout_prob=dropout_prob)
         self.linear = nn.Linear(self.bert.config.hidden_size*2, 1)
         self.similarity = nn.CosineSimilarity()
 
@@ -19,9 +19,9 @@ class SBERT_base_Model(nn.Module):
 
 
 class BERT_base_Model(nn.Module):
-    def __init__(self, model_name):
+    def __init__(self, model_name, dropout_prob):
         super(BERT_base_Model, self).__init__()
-        self.bert = AutoModelForSequenceClassification.from_pretrained(model_name, num_labels=1)
+        self.bert = AutoModelForSequenceClassification.from_pretrained(model_name, num_labels=1, hidden_dropout_prob=dropout_prob)
         self.linear = nn.Linear(self.bert.config.hidden_size, 1)
         self.similarity = nn.CosineSimilarity(dim=-1)
 
@@ -32,9 +32,9 @@ class BERT_base_Model(nn.Module):
     
 
 class BERT_base_NLI_Model(nn.Module):
-    def __init__(self, model_name):
+    def __init__(self, model_name, dropout_prob):
         super(BERT_base_NLI_Model, self).__init__()
-        self.bert = AutoModelForSequenceClassification.from_pretrained(model_name, num_labels=1)
+        self.bert = AutoModelForSequenceClassification.from_pretrained(model_name, num_labels=1, hidden_dropout_prob=dropout_prob)
         self.sigmoid = nn.Sigmoid()
         
     def forward(self, src_ids):
@@ -45,9 +45,9 @@ class BERT_base_NLI_Model(nn.Module):
     
 
 class MLM_Model(nn.Module):
-    def __init__(self, model_name):
+    def __init__(self, model_name, dropout_prob):
         super(MLM_Model, self).__init__()
-        self.bert = RobertaForMaskedLM.from_pretrained(model_name)
+        self.bert = RobertaForMaskedLM.from_pretrained(model_name, hidden_dropout_prob=dropout_prob)
         self.softmax = nn.LogSoftmax(dim=-1)
 
     def forward(self, src_ids):
@@ -55,3 +55,19 @@ class MLM_Model(nn.Module):
         outputs = self.softmax(outputs)
         
         return outputs
+
+
+class SimCSE(nn.Module):
+    def __init__(self, model_name, dropout_prob):
+        super(SimCSE, self).__init__()
+        self.bert = AutoModel.from_pretrained(model_name, hidden_dropout_prob=dropout_prob)
+        self.cosine_similarity = nn.CosineSimilarity()
+        
+    def forward(self, src_ids):
+        outputs1 = self.bert(src_ids).pooler_output
+        outputs2 = self.bert(src_ids).pooler_output
+        score = self.cosine_similarity(outputs1.unsqueeze(1), outputs2.unsqueeze(0))
+        
+        return outputs1, score
+        
+    

--- a/utils/trainer.py
+++ b/utils/trainer.py
@@ -14,23 +14,33 @@ def step(data, model_type, device, model, criterion, outputEDA=None):
         
         if outputEDA != None:
             outputEDA.appendf(label, logits, aux, s1, s2)
-    else:
-        if model_type == "MLM":
-            s1, label = data
-        else:
-            s1, label, aux = data
+            
+    elif model_type == "MLM":
+        s1, label = data
         s1 = s1.to(device)
         label = label.to(device)
         logits = model(s1).squeeze()
-        if model_type in ["BERT", "BERT_NLI"]:
-            loss = criterion(logits.squeeze(-1), label)
-            score = torchmetrics.functional.pearson_corrcoef(logits, label.squeeze())
-        elif model_type == "MLM":
-            loss = criterion(logits.transpose(1, 2), label)
-            score = torch.exp(loss)
-            
-        if model_type != "MLM" and outputEDA != None:
+        loss = criterion(logits.transpose(1, 2), label)
+        score = torch.exp(loss)
+        
+    elif model_type in ["BERT", "BERT_NLI"]:
+        s1, label, aux = data
+        s1 = s1.to(device)
+        label = label.to(device)
+        logits = model(s1).squeeze()
+        loss = criterion(logits.squeeze(-1), label)
+        score = torchmetrics.functional.pearson_corrcoef(logits, label.squeeze())
+    
+        if outputEDA != None:
             outputEDA.appendf(label, logits, aux, s1, None)
+            
+    elif model_type == "SimCSE":
+        s1, label = data
+        s1 = s1.to(device)
+        label = label.to(device)
+        logits, cos_sim = model(s1)
+        loss = criterion(cos_sim, label)
+        score = torch.IntTensor([0])
     
     return logits, loss, score
 


### PR DESCRIPTION
SimCSE unsupervised training process 추가.

config.yaml
model_type: "SimCSE"로 하면 SimCSE 학습 가능.
watch_metrics: "loss" or "score"
loss는 valid loss 기준으로 learning rate shceduler 작동. score는 valid pearson이나 valid ppl 기준으로 작동.
loss: "NLL"이랑 "CE"가 추가. "NLL"은 MLM 용, "CE"는 그 외 Cross Entropy가 필요한 학습에 사용.
dropout_prob : 0.1
Transformer 모델의 dropout prob을 설정.

